### PR TITLE
Fix interval detection for slices.

### DIFF
--- a/ceres.py
+++ b/ceres.py
@@ -333,8 +333,8 @@ class CeresNode(object):
       self.readMetadata()
 
     # Normalize the timestamps to fit proper intervals
-    fromTime = int(fromTime - (fromTime % self.timeStep) + self.timeStep)
-    untilTime = int(untilTime - (untilTime % self.timeStep) + self.timeStep)
+    fromTime = int(fromTime - (fromTime % self.timeStep))
+    untilTime = int(untilTime - (untilTime % self.timeStep))
 
     sliceBoundary = None  # to know when to split up queries across slices
     resultValues = []


### PR DESCRIPTION
Without this fix, sometimes graphite will try to display data from future.

This patch makes it less accurate, but more sane.