### PR TITLE
Return null series with proper timestamp

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,53 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0" is_locked="false">
+    <option name="myName" value="Project Default" />
+    <option name="myLocal" value="false" />
+    <inspection_tool class="InconsistentLineSeparators" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="LossyEncoding" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyArgumentEqualDefaultInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyClassicStyleClassInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
+        <value>
+          <list size="3">
+            <item index="0" class="java.lang.String" itemvalue="2.6" />
+            <item index="1" class="java.lang.String" itemvalue="2.7" />
+            <item index="2" class="java.lang.String" itemvalue="3.4" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyDocstringInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyMandatoryEncodingInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="14">
+            <item index="0" class="java.lang.String" itemvalue="whisper" />
+            <item index="1" class="java.lang.String" itemvalue="mocker" />
+            <item index="2" class="java.lang.String" itemvalue="Twisted" />
+            <item index="3" class="java.lang.String" itemvalue="raven" />
+            <item index="4" class="java.lang.String" itemvalue="structlog" />
+            <item index="5" class="java.lang.String" itemvalue="tzlocal" />
+            <item index="6" class="java.lang.String" itemvalue="Flask" />
+            <item index="7" class="java.lang.String" itemvalue="pytz" />
+            <item index="8" class="java.lang.String" itemvalue="cairocffi" />
+            <item index="9" class="java.lang.String" itemvalue="Flask-Cache" />
+            <item index="10" class="java.lang.String" itemvalue="six" />
+            <item index="11" class="java.lang.String" itemvalue="pyparsing" />
+            <item index="12" class="java.lang.String" itemvalue="mock" />
+            <item index="13" class="java.lang.String" itemvalue="nose" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="RestRoleInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredRoles">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="UnusedDefine" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="Project Default" />
+    <option name="USE_PROJECT_PROFILE" value="true" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/ceres.py
+++ b/ceres.py
@@ -329,12 +329,13 @@ class CeresNode(object):
 
   def read(self, fromTime, untilTime):
     # get biggest timeStep 
+    metadata = None
     if self.timeStep is None:
-      self.readMetadata()
+      metadata = self.readMetadata()
 
     # Normalize the timestamps to fit proper intervals
-    fromTime = int(fromTime - (fromTime % self.timeStep) + self.timeStep)
-    untilTime = int(untilTime - (untilTime % self.timeStep) + self.timeStep)
+    fromTime = int(fromTime - (fromTime % self.timeStep))
+    untilTime = int(untilTime - (untilTime % self.timeStep))
 
     sliceBoundary = None  # to know when to split up queries across slices
     resultValues = []
@@ -355,7 +356,7 @@ class CeresNode(object):
     for slice_tmp in self.slices:
       bogus = 0
       for item in slices_map.values():
-        if slice_tmp.startTime > item[0] and slice_tmp.endTime < item[1]: 
+        if (slice_tmp.startTime > item[0] and slice_tmp.endTime < item[1]) or (slice_tmp.startTime > untilTime or slice_tmp.endTime < fromTime):
           bogus = 1
       if not bogus: slices_arr.append(slice_tmp)
 
@@ -402,6 +403,18 @@ class CeresNode(object):
 
     # The end of the requested interval predates all slices
     if earliestData is None:
+      if biggest_timeStep is 1:
+          now = int(time.time())
+          try:
+              biggest_timeStep = metadata["timeStep"]
+              tmp = 0
+              for ts in metadata["retentions"]:
+                  tmp += ts[0] * ts[1]
+                  if untilTime > now - tmp:
+                      break
+                  biggest_timeStep = ts[0]
+          except TypeError:
+              biggest_timeStep = DEFAULT_TIMESTEP
       missing = int(untilTime - fromTime) / biggest_timeStep
       resultValues = [None for i in range(missing)] 
 


### PR DESCRIPTION
A bit heavier, but will behave more like other storage engines.

For example, you have series:
host.something.foo
host.something.bar
host.something.baz

when you query for 'host.something.*' and, for some reasons, you don't receive 'host.something.bar' metric, sometimes you want to have "null" values in return, but in how currently graphite behaves, you won't get anything. This will fix ceres's library part of the problem - return list of nulls with correct retention period.