### PR TITLE
Part of a merge fix

### DIFF
--- a/ceres.py
+++ b/ceres.py
@@ -621,7 +621,8 @@ class CeresSlice(object):
     if not exists(self.fsPath):
       raise SliceDeleted()
 
-    t = t - (t % self.timeStep)
+    if t % self.timeStep != 0:
+      t = t - (t % self.timeStep) + self.timeStep
     timeOffset = t - self.startTime
     if timeOffset < 0:
       return


### PR DESCRIPTION
Merge process currently can produce a lot of files with only one point there. They'll consume full inode and full filesystem's cluster, which is overkill and makes merge useless.

This make "deleteBefore" behaviour more sane from user's point of view: we need to do roundUp on time, not roundDown, when "deleteBefore" timestamp wasn't normalized by timeStep value, because this function is used in merge and rollup process, when we already know timestamp of the point.